### PR TITLE
Convert output of subprocess

### DIFF
--- a/dacman/core/diff.py
+++ b/dacman/core/diff.py
@@ -570,8 +570,8 @@ def executable_diff_mp(new_file, old_file, custom_analyzer):
       logger.error('Error analyzing changes: %s', err)
       return None
    else:
-      logger.info('Change calculation completed with output:')
       out_str = out.decode(sys.stdout.encoding).strip()
+      logger.info('Change calculation completed with output: %s', out_str)
       return out_str
                 
 #########################################################################################################

--- a/dacman/core/diff.py
+++ b/dacman/core/diff.py
@@ -554,7 +554,8 @@ def file_diff_mp(new_file, old_file, custom_analyzer, diff_analyzer):
       logger.info("Using custom executable analyzer %s", custom_analyzer)
       output = executable_diff_mp(new_file, old_file, custom_analyzer)
       if output != None and output.strip() != '':
-         print(output.decode(sys.stdout.encoding).strip())
+         out_str = output.decode(sys.stdout.encoding).strip()
+         print(out_str)
    else:
       logger.error('Analyzer type %s is not supported', type(custom_analyzer))
       raise TypeError('Analyzer type {} not supported'.format(type(custom_analyzer)))
@@ -569,8 +570,9 @@ def executable_diff_mp(new_file, old_file, custom_analyzer):
       logger.error('Error analyzing changes: %s', err)
       return None
    else:
-      logger.info('Change calculation completed with output: %s', out)
-      return out
+      logger.info('Change calculation completed with output:')
+      out_str = out.decode(sys.stdout.encoding).strip()
+      return out_str
                 
 #########################################################################################################
 


### PR DESCRIPTION
In `executable_diff_mp` the output was not decoded, causing a bytes object being returned and eventually displayed to the user.

I ran into then this when testing the CSV plugin. Since it belongs to the main library code, I created a separate branch, and will merge back into that branch later.